### PR TITLE
[feature] implements #4, printer associations to services

### DIFF
--- a/src/app/printers/usb.py
+++ b/src/app/printers/usb.py
@@ -19,16 +19,16 @@ class PrinterUSB(Printer):
         self.usb_vid = config.get('USB_VID')
         self.usb_pid = config.get('USB_PID')
         if self.usb_vid is None or self.usb_pid is None:
-            print(f"    ERROR in configuration: missing USB_VID/USB_PID values, skipping")
+            print(f"        ERROR in configuration: missing USB_VID/USB_PID values, skipping")
             return False
-        print(f"    Connecting to USB printer '{self.usb_vid}:{self.usb_pid}'...")
+        print(f"        Connecting to USB printer '{self.usb_vid}:{self.usb_pid}'...")
         usb_host.Port(board.GP26, board.GP27)
         usb.core.find() # dummy enumeration because on RP2040 first enumeration always fails
         self.device = usb.core.find(idVendor=self.usb_vid, idProduct=self.usb_pid)
         if self.device is None:
-            print(f"    ...device '{self.usb_vid}:{self.usb_pid}' not found")
+            print(f"        ...device '{self.usb_vid}:{self.usb_pid}' not found")
             return False
-        print(f"    ...connected to {self.device.idVendor:04x}:{self.device.idProduct:04x} {self.device.manufacturer} / {self.device.product} (#{self.device.serial_number})")
+        print(f"        ...connected to {self.device.idVendor:04x}:{self.device.idProduct:04x} {self.device.manufacturer} / {self.device.product} (#{self.device.serial_number})")
         self.device.set_configuration()
         return True
 

--- a/src/app/services/__init__.py
+++ b/src/app/services/__init__.py
@@ -6,6 +6,7 @@ class Service:
         self.debug = debug
 
     def setup(self, config: toml.Dotty, printers: dict) -> bool:
+        self.printers = printers
         return True
 
     def loop(self) -> bool:

--- a/src/app/services/http.py
+++ b/src/app/services/http.py
@@ -8,7 +8,6 @@ from . import Service
 
 class ServiceHTTP(Service):
     http_server: Server = None
-    printers = dict()
 
 
     def __init__(self, debug: bool):
@@ -16,6 +15,7 @@ class ServiceHTTP(Service):
 
 
     def setup(self, config: toml.Dotty, printers: dict) -> bool:
+        Service.setup(self, config, printers)
         if 'SERVER_PATH' not in config:
             print("ERROR: Missing 'SERVER_PATH' config in table/secion 'SERVICE:HTTP' in settings.toml, disabling service HTTP")
             return False
@@ -24,7 +24,6 @@ class ServiceHTTP(Service):
         self.http_server.add_routes([Route(config.get('SERVER_PATH'), POST, self._on_http_post_request)])
         self.http_server.start(config.get('SERVER_IPV4'), int(config.get('SERVER_PORT')))
         print(f"    ...HTTP server started")
-        self.printers = printers
         return True
 
 

--- a/src/app/services/mqtt.py
+++ b/src/app/services/mqtt.py
@@ -15,6 +15,7 @@ class ServiceMQTT(Service):
 
 
     def setup(self, config: toml.Dotty, printers: dict) -> bool:
+        Service.setup(self, config, printers)
         if 'BROKER_IPV4' not in config:
             print("ERROR: Missing 'BROKER_IPV4' config in table/secion 'SERVICE:MQTT' in settings.toml, disabling service MQTT")
             return False
@@ -26,8 +27,7 @@ class ServiceMQTT(Service):
                                       username=config.get('BROKER_USER'),
                                       password=config.get('BROKER_PASS'),
                                       socket_pool=socketpool.SocketPool(wifi.radio),
-                                      use_binary_mode=True,
-                                      user_data=printers)
+                                      use_binary_mode=True)
         while self.mqtt_client.is_connected() is False:
             self.mqtt_client.connect()
             time.sleep(1)
@@ -49,7 +49,7 @@ class ServiceMQTT(Service):
     def _on_mqtt_message(self, client, topic, payload):
         if self.debug is True:
             print(f"Processing MQTT message on topic '{topic}' with a payload of {len(payload)} bytes")
-        for printer in client.user_data.values():
+        for printer in self.printers.values():
             printer.write(b'\x1b\x40')
             printer.write(b'\x1b\x64\x04')
             for offset in range(0, len(payload), 64):

--- a/src/app/services/tcp.py
+++ b/src/app/services/tcp.py
@@ -7,7 +7,6 @@ from . import Service
 class ServiceTCP(Service):
     tcp_server:  socketpool.Socket = None
     client_timeout: int = 1
-    printers: dict = dict()
 
 
     def __init__(self, debug: bool):
@@ -15,19 +14,19 @@ class ServiceTCP(Service):
 
 
     def setup(self, config: toml.Dotty, printers: dict) -> bool:
+        Service.setup(self, config, printers)
         if 'SERVER_PORT' not in config:
-            print("ERROR: Missing 'SERVER_PORT' config in table/secion 'SERVICE:TCP' in settings.toml, disabling service TCP")
+            print("            ERROR: Missing 'SERVER_PORT' config in table/secion 'SERVICE:TCP' in settings.toml, disabling service TCP")
             return False
 
-        print(f"    Starting TCP server on IPv4='{config.get('SERVER_IPV4')}' and port '{config.get('SERVER_PORT')}'...")
+        print(f"        Starting TCP server on IPv4='{config.get('SERVER_IPV4')}' and port '{config.get('SERVER_PORT')}'...")
         pool = socketpool.SocketPool(wifi.radio)
         self.tcp_server = pool.socket(pool.AF_INET, pool.SOCK_STREAM)
         self.tcp_server.bind((config.get('SERVER_IPV4'), int(config.get('SERVER_PORT'))))
         self.tcp_server.listen(1)
         self.tcp_server.settimeout(0)
         self.client_timeout = int(config.get('CLIENT_TIMEOUT'))
-        print(f"    ...TCP server now started")
-        self.printers = printers
+        print(f"        ...TCP server now started")
         return True
 
 
@@ -45,9 +44,8 @@ class ServiceTCP(Service):
 
 
     def _on_tcp_connect(self, sock, addr):
-        print(self.printers)
         if self.debug is True:
-            print(f"Processing TCP connection from IPv4='{addr}'")
+            print(f"            DEBUG: Processing TCP connection from IPv4='{addr}'")
         for printer in self.printers.values():
             printer.write(b'\x1b\x40')
             printer.write(b'\x1b\x64\x04')

--- a/src/code.py
+++ b/src/code.py
@@ -51,8 +51,7 @@ try:
                     microcontroller.reset()
         loop_result = server.loop()
 except BaseException as e:
-    print(f"    FATAL: {e}")
-    pass
+    print(f"    FATAL: <{type(e).__name__}> {str(e)}")
 print(f"...server loop exited - restarting in 5 seconds")
 time.sleep(5)
 supervisor.reload()


### PR DESCRIPTION
New configuration key "PRINTERS" for services, allowing assignment of printer(s) to service(s).

...
[SERVICE:MQTT-black]
DRIVER = "MQTT"
BROKER_IPV4 = "192.168.4.1"
BROKER_TOPIC = "printer/black/escpos"
**PRINTERS = [ "black" ]**


[SERVICE:MQTT-white]
DRIVER = "MQTT"
BROKER_IPV4 = "192.168.4.1"
BROKER_TOPIC = "printer/white/escpos"
**PRINTERS = [ "white" ]**
...

...assuming configured printers "black" and "white"